### PR TITLE
ci: support varnish 9

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -18,7 +18,6 @@ builds:
       - windows
       - darwin
 
-
 archives:
   - formats: [tar.gz]
     # this name template makes the OS and Arch compatible with the results of `uname`.
@@ -35,6 +34,27 @@ archives:
         formats: [zip]
 
 dockers_v2:
+  - id: varnish-9.0.0
+    dockerfile: build/Dockerfile
+    extra_files:
+      - build/entrypoint.sh
+    images:
+      - ghcr.io/otto-de/prometheus-varnish-exporter
+    tags:
+      - "{{.Version}}-varnish-9.0.0"
+      - latest
+    build_args:
+      VARNISH_VERSION: 9.0.0
+    platforms:
+      - linux/amd64
+      - linux/arm64
+    labels:
+      "org.opencontainers.image.description": "prometheus compatible metrics exporter for varnish 9.0.0"
+      "org.opencontainers.image.created": "{{.Date}}"
+      "org.opencontainers.image.name": "{{.ProjectName}}"
+      "org.opencontainers.image.revision": "{{.FullCommit}}"
+      "org.opencontainers.image.version": "{{.Version}}"
+      "org.opencontainers.image.source": "{{.GitURL}}"
   - id: varnish-8.0.0
     dockerfile: build/Dockerfile
     extra_files:
@@ -43,7 +63,6 @@ dockers_v2:
       - ghcr.io/otto-de/prometheus-varnish-exporter
     tags:
       - "{{.Version}}-varnish-8.0.0"
-      - latest
     build_args:
       VARNISH_VERSION: 8.0.0
     platforms:


### PR DESCRIPTION
Fixes #11.

# Summary

Varnish 9 is now supported as a build target and marked as latest. We already
pushed a release for ARM64 builds for internal usage but missed to do the same
for x86 and permanently add it to goreleaser.
