### PR TITLE
chore: replace ISSUE_TEMPLATE.md with structured issue forms

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,39 @@
+name: Bug Report
+description: Report a bug with the Varnish exporter
+labels: ["bug"]
+body:
+  - type: input
+    id: varnish-version
+    attributes:
+      label: Varnish version
+      placeholder: "e.g. 7.5.0"
+    validations:
+      required: true
+  - type: input
+    id: exporter-version
+    attributes:
+      label: Exporter version
+      placeholder: "e.g. 1.8.3"
+    validations:
+      required: true
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: What happened and what did you expect?
+    validations:
+      required: true
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Steps to reproduce
+      description: Minimal steps to reproduce the issue.
+    validations:
+      required: false
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs or output
+      render: shell
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,18 @@
+name: Feature Request
+description: Suggest a new feature or improvement
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: What would you like to see added or changed?
+    validations:
+      required: true
+  - type: textarea
+    id: use-case
+    attributes:
+      label: Use case
+      description: Why is this needed? What problem does it solve?
+    validations:
+      required: false

--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,6 +1,0 @@
-* **Varnish** `fill_version`
-* **prometheus_varnish_exporter** `fill_version`
-
-------------------
-
-Message...


### PR DESCRIPTION
Replaces the 9-year-old single-file `ISSUE_TEMPLATE.md` with GitHub issue forms:

- `bug_report.yml` — structured fields for Varnish version, exporter version, description, steps, and logs
- `feature_request.yml` — description and use case

Gives contributors a guided experience and provides consistent triage data.