### PR TITLE
fix: resolve all golangci-lint issues

### DIFF
--- a/main.go
+++ b/main.go
@@ -133,13 +133,13 @@ func main() {
 	}
 
 	// Test run or user explicitly wants to exit on any scrape errors during runtime.
-	ExitHandler.exitOnError = StartParams.Test == true || StartParams.ExitOnErrors == true
+	ExitHandler.exitOnError = StartParams.Test || StartParams.ExitOnErrors
 
 	slog.Info("Initializing application", "applicationName", ApplicationName, "applicationVersion", getVersion(false), "parameters", StartParams)
 
 	// Initialize
 	if err := VarnishVersion.Initialize(); err != nil {
-		ExitHandler.Errorf("Varnish version initialize failed: %s", err.Error())
+		_ = ExitHandler.Errorf("Varnish version initialize failed: %s", err.Error())
 	}
 	if VarnishVersion.Valid() {
 		slog.Info("Found varnishstat.", "varnishVersion", VarnishVersion)
@@ -171,7 +171,7 @@ func main() {
 			if len(buf) > 0 {
 				slog.Debug("Scrape output", "output", string(buf))
 			}
-			ExitHandler.Errorf("Startup test: %s", err.Error())
+			_ = ExitHandler.Errorf("Startup test: %s", err.Error())
 		}
 	}
 	if StartParams.Test {
@@ -197,7 +197,7 @@ func main() {
 
 	if StartParams.Path != "/" {
 		http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-			w.Write([]byte(`<html>
+			_, _ = w.Write([]byte(`<html>
     <head><title>Varnish Exporter</title></head>
     <body>
         <h1>Varnish Exporter</h1>
@@ -211,7 +211,7 @@ func main() {
 			// As noted in the "up" metric, needs some way to determine if everything is actually Ok.
 			// For now, this just lets us check that we're accepting connections
 			w.WriteHeader(http.StatusOK)
-			fmt.Fprintln(w, "Ok")
+			_, _ = fmt.Fprintln(w, "Ok")
 		})
 	}
 	logFatalError(http.ListenAndServe(StartParams.ListenAddress, nil))

--- a/prometheus.go
+++ b/prometheus.go
@@ -79,7 +79,7 @@ func (pe *prometheusExporter) Collect(ch chan<- prometheus.Metric) {
 	hadError := ExitHandler.HasError()
 
 	_, err := ScrapeVarnish(ch)
-	ExitHandler.Set(err)
+	_ = ExitHandler.Set(err)
 
 	if err == nil {
 		if hadError {
@@ -247,12 +247,12 @@ func computePrometheusInfo(vName, vGroup, vIdentifier, vDescription string) (nam
 		fq := strings.ToLower(vName)
 		// Remove unique identifiers from name to group similar metrics by labeling
 		if len(vIdentifier) > 0 {
-			fq = strings.Replace(fq, "."+strings.ToLower(vIdentifier), "", -1)
+			fq = strings.ReplaceAll(fq, "."+strings.ToLower(vIdentifier), "")
 		}
 		// Make sure our group is prefixed only once
 		fq = prometheusTrimGroupPrefix(fq)
 		// Build fq name
-		name = exporterNamespace + "_" + vGroup + "_" + strings.Replace(fq, ".", "_", -1)
+		name = exporterNamespace + "_" + vGroup + "_" + strings.ReplaceAll(fq, ".", "_")
 		if swapName := fqNames[name]; len(swapName) > 0 {
 			name = swapName
 		}

--- a/utils.go
+++ b/utils.go
@@ -74,22 +74,6 @@ func startsWithAny(str string, prefixes []string, cs caseSensitivity) bool {
 	return false
 }
 
-func endsWith(str, postfix string, cs caseSensitivity) bool {
-	if cs == caseSensitive {
-		return strings.HasSuffix(str, postfix)
-	}
-	return strings.HasSuffix(strings.ToLower(str), strings.ToLower(postfix))
-}
-
-func endsWithAny(str string, postfixes []string, cs caseSensitivity) bool {
-	for _, postfix := range postfixes {
-		if endsWith(str, postfix, cs) {
-			return true
-		}
-	}
-	return false
-}
-
 // file
 
 // Returns if file/dir in path exists.

--- a/varnish.go
+++ b/varnish.go
@@ -72,22 +72,22 @@ func ScrapeVarnishFrom(buf []byte, ch chan<- prometheus.Metric) ([]byte, error) 
 		return buf, err
 	}
 
-	countersJSON := make(map[string]any)
+	var countersJSON map[string]any
 	// From Varnish 6.5 https://varnish-cache.org/docs/6.5/whats-new/upgrading-6.5.html#varnishstat
 	if metricsJSON["version"] != nil {
 		version_raw, ok := metricsJSON["version"].(json.Number)
 		if !ok {
-			return nil, fmt.Errorf("Unhandled json stats version type: %T %#v", metricsJSON["version"], metricsJSON["version"])
+			return nil, fmt.Errorf("unhandled json stats version type: %T %#v", metricsJSON["version"], metricsJSON["version"])
 		}
 		version, err := version_raw.Int64()
 		if err != nil {
-			return nil, fmt.Errorf("Unhandled json stats version type: %s", err)
+			return nil, fmt.Errorf("unhandled json stats version type: %s", err)
 		}
 		switch version {
 		case 1:
 			countersJSON = metricsJSON["counters"].(map[string]any)
 		default:
-			return nil, fmt.Errorf("Unimplemented json stats version %d", version)
+			return nil, fmt.Errorf("unimplemented json stats version %d", version)
 		}
 	} else {
 		countersJSON = metricsJSON
@@ -282,7 +282,7 @@ func (v *varnishVersion) queryVersion() error {
 	if scanner := bufio.NewScanner(buf); scanner.Scan() {
 		return v.parseVersion(scanner.Text())
 	}
-	return fmt.Errorf("Failed to get varnishstat -V output")
+	return fmt.Errorf("failed to get varnishstat -V output")
 }
 
 func (v *varnishVersion) parseVersion(version string) error {
@@ -302,7 +302,7 @@ func (v *varnishVersion) parseVersion(version string) error {
 		}
 	}
 	if !v.Valid() {
-		return fmt.Errorf("Failed to resolve version from %q", version)
+		return fmt.Errorf("failed to resolve version from %q", version)
 	}
 	return nil
 }

--- a/varnish_test.go
+++ b/varnish_test.go
@@ -162,7 +162,9 @@ func Test_VarnishMetrics(t *testing.T) {
 	}
 	for _, version := range testFileVersions {
 		test := filepath.Join(dir, "test/scrape", version+".json")
-		VarnishVersion.parseVersion(version)
+		if err := VarnishVersion.parseVersion(version); err != nil {
+			t.Fatal(err)
+		}
 		t.Logf("test scrape %s", VarnishVersion)
 
 		buf, err := os.ReadFile(test)
@@ -281,7 +283,9 @@ func Test_PrometheusExport(t *testing.T) {
 	}
 	for _, version := range testFileVersions {
 		test := filepath.Join(dir, "test/scrape", version+".json")
-		VarnishVersion.parseVersion(version)
+		if err := VarnishVersion.parseVersion(version); err != nil {
+			t.Fatal(err)
+		}
 		t.Logf("test scrape %s", VarnishVersion)
 
 		registry := prometheus.NewRegistry()


### PR DESCRIPTION
Fixes all issues reported by golangci-lint (verified with v2.12.2 / Go 1.25).

## Changes

| File | Issue | Fix |
|------|-------|-----|
| `main.go` | `ST1000`: redundant `== true` bool comparisons | Simplified to plain boolean |
| `main.go` | `errcheck`: unchecked returns from `ExitHandler.Errorf` | Added `_ =` assignments |
| `main.go` | `errcheck`: unchecked returns from `w.Write` / `fmt.Fprintln` | Added `_, _ =` assignments |
| `prometheus.go` | `errcheck`: unchecked return from `ExitHandler.Set` | Added `_ =` assignment |
| `prometheus.go` | `SA1007`: `strings.Replace` with `-1` | Replaced with `strings.ReplaceAll` |
| `varnish.go` | `ineffassign`: `countersJSON` assigned but overwritten | Changed to `var countersJSON map[string]any` |
| `varnish.go` | `ST1005`: capitalized error strings | Lowercased to comply with Go conventions |
| `utils.go` | `unused`: `endsWith` / `endsWithAny` functions never called | Removed both functions |
| `varnish_test.go` | `errcheck`: `parseVersion` return value ignored | Added `t.Fatal` error handling |

## Verification

```
$ golangci-lint run ./...
0 issues.

$ go test ./...
ok  	github.com/otto-de/prometheus_varnish_exporter	0.411s
```